### PR TITLE
Use standard __ANDROID__ preprocessor macro

### DIFF
--- a/log.c
+++ b/log.c
@@ -44,7 +44,7 @@ static void fprint_timestamp(
 
 static void stderr_msg(const char *file, int line, const char *func, int priority, const char *message, const char *appendix)
 {
-#ifndef ANDROID
+#ifndef __ANDROID__
 	fprint_timestamp(stderr, file, line, func, priority, message, appendix);
 #endif
 }

--- a/main.c
+++ b/main.c
@@ -29,7 +29,7 @@
 
 extern app_subsys redsocks_subsys;
 extern app_subsys base_subsys;
-#ifndef ANDROID
+#ifndef __ANDROID__
 extern app_subsys redudp_subsys;
 extern app_subsys dnstc_subsys;
 #endif
@@ -37,7 +37,7 @@ extern app_subsys dnstc_subsys;
 app_subsys *subsystems[] = {
 	&redsocks_subsys,
 	&base_subsys,
-#ifndef ANDROID
+#ifndef __ANDROID__
 	&redudp_subsys,
 	&dnstc_subsys,
 #endif


### PR DESCRIPTION
Other suggestions:

1. Make `shadowsocks-android` the default branch;
2. Consider updating to the latest stable release?